### PR TITLE
Simplify package.json build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "next-news",
   "license": "MIT",
   "dependencies": {
-    "@mars/heroku-nextjs-build": "^2.0.0",
     "firebase": "^3.7.3",
     "ms": "^1.0.0",
     "next": "^2.0.0",
@@ -13,14 +12,10 @@
   },
   "scripts": {
     "dev": "next",
-    "build": "next build",
     "start": "next start -p $PORT",
-    "heroku-postbuild": "heroku-nextjs-build"
+    "heroku-postbuild": "next build"
   },
   "engines": {
     "node": "6.9.x"
-  },
-  "cacheDirectories": [
-    "nextjs/node_modules"
-  ]
+  }
 }


### PR DESCRIPTION
This removes `heroku-nextjs-build` since the issue that it works around (absolute paths) was fixed in https://github.com/zeit/next.js/pull/1164

All that we need to do on heroku now is add: `"heroku-postbuild": "next build"` to `scripts` and pass the `$PORT` parameter.